### PR TITLE
Update OpenAPI Generator and sample programs

### DIFF
--- a/README_EN.md
+++ b/README_EN.md
@@ -22,7 +22,7 @@ These code samples show how to use Python to call APIs.
 Install the software below to organize environment.
 
 1. Python 3.10 or above
-2. OpenAPI generator 6.1.0
+2. OpenAPI generator 7.22.0
 3. Set the following environment variables.
    - ACCOUNT_ID          : Account ID (required)
    - ACCESS_TOKEN        : Access token (required)

--- a/README_JA.md
+++ b/README_JA.md
@@ -23,7 +23,7 @@
 Python環境を構築するために、以下をインストールしてください。
 
 1. Python 3.10以上のバージョン
-2. OpenAPI generator 6.1.0
+2. OpenAPI generator 7.22.0
 3. 以下の環境変数を設定します。
    - ACCOUNT_ID          : アカウントIDを記述してください(必須)。
    - ACCESS_TOKEN        : アクセストークンを記述してください(必須)。

--- a/report_sample.py
+++ b/report_sample.py
@@ -6,13 +6,13 @@ import configparser
 import openapi_client
 import os
 from openapi_client.api.report_definition_service_api import ReportDefinitionServiceApi
-from openapi_client.model.report_definition import ReportDefinition
-from openapi_client.model.report_definition_service_download_selector import ReportDefinitionServiceDownloadSelector
-from openapi_client.model.report_definition_service_operation import ReportDefinitionServiceOperation
-from openapi_client.model.report_definition_service_report_date_range_type import ReportDefinitionServiceReportDateRangeType
-from openapi_client.model.report_definition_service_report_job_status import ReportDefinitionServiceReportJobStatus
-from openapi_client.model.report_definition_service_report_type import ReportDefinitionServiceReportType
-from openapi_client.model.report_definition_service_selector import ReportDefinitionServiceSelector
+from openapi_client.models.report_definition import ReportDefinition
+from openapi_client.models.report_definition_service_download_selector import ReportDefinitionServiceDownloadSelector
+from openapi_client.models.report_definition_service_operation import ReportDefinitionServiceOperation
+from openapi_client.models.report_definition_service_report_date_range_type import ReportDefinitionServiceReportDateRangeType
+from openapi_client.models.report_definition_service_report_job_status import ReportDefinitionServiceReportJobStatus
+from openapi_client.models.report_definition_service_report_type import ReportDefinitionServiceReportType
+from openapi_client.models.report_definition_service_selector import ReportDefinitionServiceSelector
 from openapi_client.rest import ApiException
 from pprint import pprint
 
@@ -88,10 +88,9 @@ with openapi_client.ApiClient(configuration) as api_client:
     try:
         api_response = api_instance.report_definition_service_download_post(
             base_account_id,
-            report_definition_service_download_selector=report_definition_service_download_selector,
-            _preload_content=False) # OpenAPI Python Bug 4847
+            report_definition_service_download_selector=report_definition_service_download_selector)
         with open("download/sample.csv", mode="wb") as f:
-            f.write(api_response.read())
+            f.write(api_response)
 
     except ApiException as e:
         print("Exception when calling ReportDefinitionServiceApi->report_definition_service_download_post: %s\n" % e)


### PR DESCRIPTION
Updated the required OpenAPI Generator version from 6.2.0 or later to 7.22.0 or later.
Updated the sample programs accordingly.